### PR TITLE
Add revision 1

### DIFF
--- a/src/components/NewsSlider/NewsSlider.tsx
+++ b/src/components/NewsSlider/NewsSlider.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@chakra-ui/react';
+import { Box, Text } from '@chakra-ui/react';
 import WhiteDesktopSlider from './WhiteDesktopSlider';
 import WhiteMobileSlider from './WhiteMobileSlider';
 import { FC } from 'react';
@@ -13,17 +13,18 @@ interface INewsSlidesProps {
 const NewsSlider: FC<INewsSlidesProps> = ({ withoutImageVariant, slides, showNewsTitle }) => {
   return (
     <>
-      <Box px="4" my={{ md: '50', lg: 0 }}>
+      <Box px="4" my={{ md: '50', lg: 20 }}>
         <WhiteDesktopSlider showTitle={showNewsTitle} slides={slides} />
       </Box>
 
       {/* Form mobile */}
-      <Box my="16">
-        <WhiteMobileSlider
-          withoutImageVariant={withoutImageVariant}
-          showTitle={showNewsTitle}
-          slides={slides}
-        />
+      <Box my="16" display={{ base: 'block', md: 'none' }}>
+        {showNewsTitle && (
+          <Text pl="8" variant="cursive" fontSize="xl">
+            News
+          </Text>
+        )}
+        <WhiteMobileSlider withoutImageVariant={withoutImageVariant} slides={slides} />
       </Box>
     </>
   );

--- a/src/components/NewsSlider/WhiteMobileSlider.tsx
+++ b/src/components/NewsSlider/WhiteMobileSlider.tsx
@@ -17,17 +17,15 @@ import { INewsSlides } from 'types/commonTypes';
 
 interface IWhiteMobileSliderProps {
   slides: INewsSlides[];
-  showTitle?: boolean;
   withoutImageVariant?: boolean;
 }
 
 const WhiteMobileSlider: FC<IWhiteMobileSliderProps> = ({
   withoutImageVariant = false,
   slides,
-  showTitle = false,
 }) => {
   return (
-    <Container maxW={CONTAINER_MAX_WIDTH} display={{ base: 'block', md: 'none' }}>
+    <Container maxW={CONTAINER_MAX_WIDTH}>
       <Slider {...settings} className="white_slider">
         {slides.map((slide, i) => (
           <Box key={i}>
@@ -74,11 +72,6 @@ const WhiteMobileSlider: FC<IWhiteMobileSliderProps> = ({
               </Stack>
             ) : (
               <>
-                {showTitle && (
-                  <Text variant="cursive" fontSize="xl">
-                    News
-                  </Text>
-                )}
                 <Stack
                   mx="2"
                   mb="4"

--- a/src/pages/Dekorationens/DekorationenHero.tsx
+++ b/src/pages/Dekorationens/DekorationenHero.tsx
@@ -18,6 +18,15 @@ export const settings: Settings = {
 };
 
 const DekorationenHero: FC<IDekorationenHeroProps> = () => {
+  const slides = [
+    {
+      image: 'images/decorationen/slider/slider_image.png',
+    },
+    {
+      image: 'images/decorationen/slider/slider_image.png',
+    },
+  ];
+
   return (
     <Stack pos="relative">
       <VStack
@@ -47,22 +56,17 @@ const DekorationenHero: FC<IDekorationenHeroProps> = () => {
         <Box pos="absolute" bottom="0" w="full">
           <Container maxW={CONTAINER_MAX_WIDTH} mb={{ base: '0', md: '16' }}>
             <Slider {...settings} className="big_slider">
-              <Box pb="8">
-                <Box
-                  borderRadius={{ base: '8', md: '16', lg: '24' }}
-                  overflow="hidden"
-                  boxShadow="dark">
-                  <Image w="100%" src="images/decorationen/slider/slider_image.png" />
+              {slides.map((slide, index) => (
+                <Box key={index}>
+                  <Box
+                    m={{ base: 2, md: 4 }}
+                    borderRadius={{ base: '8', md: '16', lg: '24' }}
+                    overflow="hidden"
+                    boxShadow={{ base: 'light', md: 'dark' }}>
+                    <Image w="100%" src={slide.image} />
+                  </Box>
                 </Box>
-              </Box>
-              <Box pb="8">
-                <Box
-                  borderRadius={{ base: '8', md: '16', lg: '24' }}
-                  overflow="hidden"
-                  boxShadow="dark">
-                  <Image w="100%" src="images/decorationen/slider/slider_image.png" />
-                </Box>
-              </Box>
+              ))}
             </Slider>
           </Container>
         </Box>

--- a/src/pages/Home/NewsSection/NewsSection.tsx
+++ b/src/pages/Home/NewsSection/NewsSection.tsx
@@ -8,7 +8,7 @@ interface INewsSectionProps {}
 const NewsSection: FC<INewsSectionProps> = () => {
   return (
     <Container
-      h={{ base: 'auto', lg: '50rem' }}
+      h={{ base: 'auto', lg: '44rem' }}
       alignItems={{ base: 'center', lg: 'start' }}
       justifyContent="space-between"
       flexDirection={{ base: 'column-reverse', md: 'column', lg: 'row' }}

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -42,7 +42,7 @@ const theme = extendTheme(
 
     fontSizes: {
       xs: '0.75rem', // 12px
-      sm: '0.938rem', // 15px
+      sm: '.9375rem', // 15px
       md: '1.25rem', // 20px
       lg: '1.5rem', // 24px
       xl: '1.875rem', // 30px
@@ -110,18 +110,18 @@ const theme = extendTheme(
           },
           sm: {
             fontSize: 'sm',
-            px: 5,
-            py: 5,
+            px: '1.25rem',
+            py: '.625rem',
           },
           md: {
             fontSize: 'md',
-            px: 8,
-            py: 6,
+            px: '1.875rem',
+            py: '.9375rem',
           },
           lg: {
             fontSize: '1.375rem',
-            px: 8,
-            py: 4,
+            px: '1.875rem',
+            py: '.9375rem',
           },
         },
         // Two variants: outline and solid
@@ -197,13 +197,13 @@ const theme = extendTheme(
             fontSize: { base: 'xl', lg: '3xl', xl: '4xl' },
           },
           80: {
-            fontSize: { base: 'xl', md: '2xl', lg: '4xl', xl: '5xl', '2xl': '6xl' },
+            fontSize: { base: 'xl', md: '2xl', lg: '5xl', xl: '6xl' },
           },
           100: {
-            fontSize: { base: 'xl', md: '3xl', lg: '7xl', '2xl': '8xl' },
+            fontSize: { base: 'xl', md: '3xl', lg: '7xl', xl: '8xl' },
           },
           120: {
-            fontSize: { base: 'xl', md: '4xl', lg: '8xl', '2xl': '10xl' },
+            fontSize: { base: 'xl', md: '4xl', lg: '8xl', xl: '10xl' },
             lineHeight: { md: '5rem' },
           },
         },


### PR DESCRIPTION
Dekoration: Mobile view shows two „Großhandle“ cards instead of the 4 different ones on desktop view

Mobile news slider: Headline should not swipe with the cards below

Dekorationen: Main slider image is not rounded while sliding

Dekorationen: „Hochzeitballon“ headline does not match design file font size

Padding of all buttons is not identical with design