### PR TITLE
fix: handle optional chaining for offsetTop in scroll.ts

### DIFF
--- a/src/components/hooks/scroll.ts
+++ b/src/components/hooks/scroll.ts
@@ -64,7 +64,7 @@ export const useScrollShow = (
 
       const scrollPositionRelativeToRef =
         target.documentElement.scrollTop -
-        (offsetTop ? offsetTop : ref.current!.offsetTop) -
+        (offsetTop ? offsetTop : ref.current?.offsetTop || 0) -
         (noScroll ? 999999999 : offset)
 
       if (!display && scrollPositionRelativeToRef >= 0) {


### PR DESCRIPTION
Refactor the code in scroll.ts to handle optional chaining (?.) for the offsetTop property. This ensures that the code doesn't throw an error when ref.current is null or undefined. The offsetTop value is used in the calculation of scrollPositionRelativeToRef. This fix addresses a potential bug where the code could break if ref.current is not available.